### PR TITLE
Fix rust-analyzer target to `thumbv8m.main-none-eabihf`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "rust-analyzer.cargo.target": "thumbv6m-none-eabi",
+    "rust-analyzer.cargo.target": "thumbv8m.main-none-eabihf",
     "rust-analyzer.check.allTargets": false,
     "editor.formatOnSave": true
 }


### PR DESCRIPTION
Currently, the target of `rust-analyzer` is for RP2040, not for RP235x. This pull request fixes the setting.