### PR TITLE
fix: Use edition 2024 by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "rp235x-project-template"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ If you aren't using a debugger (or want to use other debugging configurations), 
 <details open="open">
   <summary><h2 style="display: inline-block" id="requirements">Requirements</h2></summary>
   
-- The standard Rust tooling (cargo, rustup) which you can install from https://rustup.rs/
+- The standard Rust tooling (cargo, rustup) which you can install from <https://rustup.rs/>
+  
+  Note that, this template targets Rust 2024 edition, which requires Rust 1.85. So, it is recommended to use the latest stable version.
 
 - Toolchain support for the cortex-m33 processors in the rp235x (thumbv8m.main-none-eabihf)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn main() -> ! {
 }
 
 /// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
+#[unsafe(link_section = ".bi_entries")]
 #[used]
 pub static PICOTOOL_ENTRIES: [rp235x_hal::binary_info::EntryAddr; 5] = [
     rp235x_hal::binary_info::rp_cargo_bin_name!(),


### PR DESCRIPTION
This supersedes https://github.com/rp-rs/rp235x-project-template/pull/3.

The problem is that, while this template uses edition 2021, `cargo generate` generates a crate with the default edition of the toolchain. So, this compile failure is what a user would see if they uses the latest stable version of Rust.

```
error: unsafe attribute used without unsafe
  --> src\main.rs:77:3
   |
77 | #[link_section = ".bi_entries"]
   |   ^^^^^^^^^^^^ usage of unsafe attribute
   |
help: wrap the attribute in `unsafe(...)`
   |
77 | #[unsafe(link_section = ".bi_entries")]
   |   +++++++                            +

error: could not compile `rp235x-project-template` (bin "rp235x-project-template") due to 1 previous error
```

Marking the attribute in `unsafe(...)` doesn't require Rust 2024 edition (this syntax is valid since Rust 1.82 as suggested in https://github.com/rp-rs/rp235x-project-template/pull/3#issuecomment-3064537308), but, since this repository is tested against the stable and nightly version, I think it's a good idea to test with the default edition of such toolchains.