### PR TITLE
Update references to use 2.2.0 for pico-sdk's RP2350.svd

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,7 @@
                     "programBinary": "target/thumbv8m.main-none-eabihf/debug/rp235x-project-template",
                     "rttEnabled": true
                     // Uncomment this if you've downloaded the SVD from
-                    // https://github.com/raspberrypi/pico-sdk/raw/2.1.1/src/rp2350/hardware_regs/RP2350.svd
+                    // https://github.com/raspberrypi/pico-sdk/raw/2.2.0/src/rp2350/hardware_regs/RP2350.svd
                     // and placed it in the .vscode directory
                     // "svdFile": "./.vscode/rp235x.svd",
                 }

--- a/cargo-generate/launch.json
+++ b/cargo-generate/launch.json
@@ -26,7 +26,7 @@
                     "programBinary": "target/thumbv8m.main-none-eabihf/debug/{{project-name}}",
                     "rttEnabled": true
                     // Uncomment this if you've downloaded the SVD from
-                    // https://github.com/raspberrypi/pico-sdk/raw/2.1.1/src/rp2350/hardware_regs/RP2350.svd
+                    // https://github.com/raspberrypi/pico-sdk/raw/2.2.0/src/rp2350/hardware_regs/RP2350.svd
                     // and placed it in the .vscode directory
                     // "svdFile": "./.vscode/rp235x.svd",
                 }


### PR DESCRIPTION
I'm not sure how this file gets used yet, but when I saw a version specified in the path, I went to check to see if it had changed.

https://github.com/raspberrypi/pico-sdk/releases/tag/2.2.0 includes https://github.com/raspberrypi/pico-sdk/pull/2599 which includes changes to src/rp2350/hardware_regs/RP2350.svd

